### PR TITLE
add GitHub Integration workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,7 +61,7 @@ jobs:
     - name: SSH Agent
       run: |
         ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-        ssh-add ${{ steps.project.outputs.projectSSHPrivateKeyFile }}
+        ssh-add $METAL_SSH_PRIVATE_KEY_FILE
     - name: Terraform Vars - Cluster Name
       run:  echo "TF_VAR_vcenter_cluster_name=tfacc-${SHORT_SHA}" >> $GITHUB_ENV
     - name: Terraform Vars - Project ID

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,7 +23,7 @@ jobs:
         - vmware_os: vmware_esxi_7_0
           vcenter_iso: VMware-VCSA-all-7.0.0-16189094.iso
     env:
-      SSH_AUTH_SOCK: ${{ runner.temp }}/ssh_agent.sock
+      SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       TF_IN_AUTOMATION: 1
       TF_VERSION: ${{ matrix.tf }}
       TF_VAR_control_plane_node_count: 0

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,80 @@
+name: 'integration'
+# This workflow intends to verify that the module provisions
+# successfully for all software and infrastructure defined.
+# https://learn.hashicorp.com/tutorials/terraform/automate-terraform
+
+on:
+  push:
+    paths-ignore:
+      - 'LICENSE'
+      - '**.md'
+
+jobs:
+  integrate:
+    name: Integration Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        tf: [0.13.2]
+        vsphere:
+        - vmware_os: vmware_esxi_6_7
+          vcenter_iso: VMware-VCSA-all-6.7.0-14367737.iso
+        - vmware_os: vmware_esxi_7_0
+          vcenter_iso: VMware-VCSA-all-7.0.0-16189094.iso
+    env:
+      TF_IN_AUTOMATION: 1
+      TF_VERSION: ${{ matrix.tf }}
+      TF_VAR_control_plane_node_count: 0
+      TF_VAR_vcenter_iso_name: ${{ matrix.vsphere.vcenter_iso }}
+      TF_VAR_vmware_os: ${{ matrix.vsphere.vmware_os }}
+      TF_VAR_esxi_host_count: 1
+      TF_VAR_esxi_size      : "c3.medium.x86"
+      TF_VAR_router_size    : "c2.medium.x86"
+      TF_VAR_facility       : "dfw2"
+      TF_VAR_create_project : false
+      # TODO only provide this to terraform steps that need it
+      TF_VAR_auth_token: ${{ secrets.METAL_AUTH_TOKEN }}
+      TF_VAR_s3_url:           ${{ secrets.S3_URL }}
+      TF_VAR_s3_bucket_name:    ${{ secrets.S3_BUCKET_NAME }}
+      TF_VAR_s3_access_key:     ${{ secrets.S3_ACCESS_KEY }}
+      TF_VAR_s3_secret_key:     ${{ secrets.S3_SECRET_KEY }}
+    steps:
+    - name: Checkout from Github
+      uses: actions/checkout@v2
+    - name: Add SHORT_SHA env property with commit short sha
+      run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+
+    - name: Install Terraform
+      uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: ${{ env.TF_VERSION }}
+    - name: Initialize Terraform, Modules, and Plugins
+      id: init
+      run: terraform init -input=false
+    - id: project
+      uses: displague/metal-project-action@v0.5.0
+      env:
+        METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}
+    - name: Terraform Vars - Cluster Name
+      run:  echo "TF_VAR_vcenter_cluster_name=tfacc-${SHORT_SHA}" >> $GITHUB_ENV
+    - name: Terraform Vars - Project ID
+      run: echo "TF_VAR_project_id=${{ steps.project.outputs.projectID }}" >> $GITHUB_ENV
+    - name: Terraform Plan
+      id: plan
+      timeout-minutes: 45
+      run: terraform plan -out=tfplan -input=false
+    - name: Terraform Apply
+      id: apply
+      timeout-minutes: 45
+      run: terraform apply -input=false tfplan
+    - name: Terraform Destroy
+      id: destroy
+      if: ${{ always() }}
+      run: terraform destroy -input=false -auto-approve
+    - name: Project Delete
+      if: ${{ always() }}
+      uses: displague/metal-sweeper-action@v0.3.0
+      env:
+        METAL_PROJECT_ID: ${{ steps.project.outputs.projectID }}
+        METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,6 +23,7 @@ jobs:
         - vmware_os: vmware_esxi_7_0
           vcenter_iso: VMware-VCSA-all-7.0.0-16189094.iso
     env:
+      SSH_AUTH_SOCK: ${{ runner.temp }}/ssh_agent.sock
       TF_IN_AUTOMATION: 1
       TF_VERSION: ${{ matrix.tf }}
       TF_VAR_control_plane_node_count: 0
@@ -53,9 +54,14 @@ jobs:
       id: init
       run: terraform init -input=false
     - id: project
-      uses: displague/metal-project-action@v0.5.0
+      uses: displague/metal-project-action@v0.6.0
       env:
         METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}
+    # Configure an SSH Agent with a key that can access the project
+    - name: SSH Agent
+      run: |
+        ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+        ssh-add ${{ steps.project.outputs.projectSSHPrivateKeyFile }}
     - name: Terraform Vars - Cluster Name
       run:  echo "TF_VAR_vcenter_cluster_name=tfacc-${SHORT_SHA}" >> $GITHUB_ENV
     - name: Terraform Vars - Project ID

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,7 +54,7 @@ jobs:
       id: init
       run: terraform init -input=false
     - id: project
-      uses: displague/metal-project-action@v0.6.0
+      uses: displague/metal-project-action@v0.9.0
       env:
         METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}
     # Configure an SSH Agent with a key that can access the project

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,16 +30,16 @@ jobs:
       TF_VAR_vcenter_iso_name: ${{ matrix.vsphere.vcenter_iso }}
       TF_VAR_vmware_os: ${{ matrix.vsphere.vmware_os }}
       TF_VAR_esxi_host_count: 1
-      TF_VAR_esxi_size      : "c3.medium.x86"
-      TF_VAR_router_size    : "c2.medium.x86"
-      TF_VAR_facility       : "dfw2"
+      TF_VAR_esxi_size: "c3.medium.x86"
+      TF_VAR_router_size: "c2.medium.x86"
+      TF_VAR_facility: "dfw2"
       TF_VAR_create_project : false
       # TODO only provide this to terraform steps that need it
       TF_VAR_auth_token: ${{ secrets.METAL_AUTH_TOKEN }}
-      TF_VAR_s3_url:           ${{ secrets.S3_URL }}
-      TF_VAR_s3_bucket_name:    ${{ secrets.S3_BUCKET_NAME }}
-      TF_VAR_s3_access_key:     ${{ secrets.S3_ACCESS_KEY }}
-      TF_VAR_s3_secret_key:     ${{ secrets.S3_SECRET_KEY }}
+      TF_VAR_s3_url: ${{ secrets.S3_URL }}
+      TF_VAR_s3_bucket_name: ${{ secrets.S3_BUCKET_NAME }}
+      TF_VAR_s3_access_key: ${{ secrets.S3_ACCESS_KEY }}
+      TF_VAR_s3_secret_key: ${{ secrets.S3_SECRET_KEY }}
     steps:
     - name: Checkout from Github
       uses: actions/checkout@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,14 +54,14 @@ jobs:
       id: init
       run: terraform init -input=false
     - id: project
-      uses: displague/metal-project-action@v0.9.0
+      uses: displague/metal-project-action@v0.10.0
       env:
         METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}
     # Configure an SSH Agent with a key that can access the project
     - name: SSH Agent
       run: |
         ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-        ssh-add $METAL_SSH_PRIVATE_KEY_FILE
+        ssh-add <(echo $METAL_SSH_PRIVATE_KEY_BASE64 | base64 -d)
     - name: Terraform Vars - Cluster Name
       run:  echo "TF_VAR_vcenter_cluster_name=tfacc-${SHORT_SHA}" >> $GITHUB_ENV
     - name: Terraform Vars - Project ID

--- a/main.tf
+++ b/main.tf
@@ -223,7 +223,10 @@ resource "null_resource" "copy_gcs_key" {
 }
 
 resource "null_resource" "download_vcenter_iso" {
-  depends_on = [null_resource.copy_gcs_key]
+  depends_on = [
+    null_resource.run_pre_reqs,
+    null_resource.copy_gcs_key,
+  ]
   connection {
     type        = "ssh"
     user        = local.ssh_user
@@ -274,7 +277,10 @@ data "template_file" "vpn_installer" {
 }
 
 resource "null_resource" "install_vpn_server" {
-  depends_on = [null_resource.download_vcenter_iso]
+  depends_on = [
+    null_resource.run_pre_reqs,
+    null_resource.download_vcenter_iso,
+  ]
   connection {
     type        = "ssh"
     user        = local.ssh_user
@@ -323,13 +329,16 @@ data "template_file" "vcva_template" {
 }
 
 resource "null_resource" "copy_vcva_template" {
-  depends_on = [null_resource.run_pre_reqs]
+  depends_on = [
+    null_resource.run_pre_reqs,
+  ]
   connection {
     type        = "ssh"
     user        = local.ssh_user
     private_key = chomp(tls_private_key.ssh_key_pair.private_key_pem)
     host        = metal_device.router.access_public_ipv4
   }
+
   provisioner "file" {
     content     = data.template_file.vcva_template.rendered
     destination = "$HOME/bootstrap/vcva_template.json"

--- a/variables.tf
+++ b/variables.tf
@@ -86,7 +86,7 @@ variable "router_hostname" {
 
 variable "esxi_hostname" {
   description = "This is the hostname prefix for your esxi hosts. A number will be added to the end."
-  default        = "esx"
+  default     = "esx"
 }
 
 variable "router_size" {


### PR DESCRIPTION
Adds integration testing for 6.7 and 7.0 VMWare + VSphere configurations, deploying a minimal cluster on Equinix Metal for each of the two versions.


TODO:
* [x] I need to add a secret for `S3_URL` before this can work. Other variables have already been added. (ideally the bucket is in the same facility or region as the EM deployment)
* [x] Push the necessary vmware iso images into the bucket
* [x] I think SSH keys are going to be needed in this test (rather than root pass auth) for the SSH provisioners. I intend to resolve https://github.com/displague/metal-project-action/issues/3 so that a dynamically generated project will be created with a SSH key that the workflow can use in subsequent steps.


Fixes #9 
