### PR TITLE
change module pathing with gcs and datastore

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ locals {
   ssh_user               = "root"
   project_name_sanitized = replace(var.project_name, "/[ ]/", "_")
   ssh_key_name           = format("%s-%s-key", local.project_name_sanitized, random_string.ssh_unique.result)
+  gcs_key_path           = coalesce(abspath(var.path_to_gcs_key), fileset(path.module, var.relative_path_to_gcs_key)[0], fileset(path.cwd, var.gcs_key_name)[0])
 }
 
 resource "metal_project" "new_project" {
@@ -217,7 +218,7 @@ resource "null_resource" "copy_gcs_key" {
     host        = metal_device.router.access_public_ipv4
   }
   provisioner "file" {
-    content     = file("${path.module}/${var.relative_path_to_gcs_key}")
+    content     = file(local.gcs_key_path)
     destination = "$HOME/bootstrap/gcp_storage_reader.json"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -11,8 +11,11 @@ resource "random_string" "ssh_unique" {
 locals {
   ssh_user               = "root"
   project_name_sanitized = replace(var.project_name, "/[ ]/", "_")
-  ssh_key_name           = format("%s-%s-key", local.project_name_sanitized, random_string.ssh_unique.result)
-  gcs_key_path           = coalesce(abspath(var.path_to_gcs_key), fileset(path.module, var.relative_path_to_gcs_key), fileset(path.cwd, var.gcs_key_name))
+
+  ssh_key_name = format("%s-%s-key", local.project_name_sanitized, random_string.ssh_unique.result)
+
+  gcs_keys_cwd = flatten([[fileset(path.cwd, var.gcs_key_name)], ""])
+  gcs_key_path = coalesce(abspath(var.path_to_gcs_key), path.module, var.relative_path_to_gcs_key, local.gcs_keys_cwd[0])
 }
 
 resource "metal_project" "new_project" {

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ locals {
   ssh_user               = "root"
   project_name_sanitized = replace(var.project_name, "/[ ]/", "_")
   ssh_key_name           = format("%s-%s-key", local.project_name_sanitized, random_string.ssh_unique.result)
-  gcs_key_path           = coalesce(abspath(var.path_to_gcs_key), fileset(path.module, var.relative_path_to_gcs_key)[0], fileset(path.cwd, var.gcs_key_name)[0])
+  gcs_key_path           = coalesce(abspath(var.path_to_gcs_key), fileset(path.module, var.relative_path_to_gcs_key), fileset(path.cwd, var.gcs_key_name))
 }
 
 resource "metal_project" "new_project" {

--- a/main.tf
+++ b/main.tf
@@ -452,7 +452,7 @@ resource "null_resource" "deploy_vcva" {
   }
 
   provisioner "file" {
-    source      = "templates/extend_datastore.sh"
+    source      = "${path.module}/templates/extend_datastore.sh"
     destination = "$HOME/bootstrap/extend_datastore.sh"
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -192,9 +192,19 @@ variable "object_store_bucket_name" {
   default     = "vmware"
 }
 
-variable "relative_path_to_gcs_key" {
-  description = "If you are using GCS to download you vCenter ISO this is the path to the GCS key"
+variable "gcs_key_name" {
+  description = "If you are using GCS to download your vCenter ISO this is the name of the GCS key"
   default     = "storage-reader-key.json"
+}
+
+variable "path_to_gcs_key" {
+  description = "If you are using GCS to download your vCenter ISO this is the absolute path to the GCS key (ex: /home/example/storage-reader-key.json)"
+  default     = ""
+}
+
+variable "relative_path_to_gcs_key" {
+  description = "(Deprecated: use path_to_gcs_key) If you are using GCS to download your vCenter ISO this is the path to the GCS key"
+  default     = ""
 }
 
 variable "vcenter_iso_name" {


### PR DESCRIPTION
Fixes #25: When used in downstream modules, the GCS key path needed to be relative to the vsphere module, not the parent module.  `relative_path_to_gcs_key` has been deprecated for `path_to_gcs_key`.  Additionally, the behavior has changed so that when `relative_path_to_gcs_key` is not specified, the default key name (the same name expected previously) will be searched in `path.cwd` (the parent module) rather than `path.module` (this module).

Fixes #24: Added a missing `path.module` to a script contained within this module. 