### PR TITLE
reformat all python scripts with black

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,25 @@
+name: Python package
+
+on:
+- push
+- pull_request
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+        - 3.6 # Match the version on the gateway node
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - id: fmt_and_lint
+      run: |
+        pip install black==21.4b2 pylama
+        black --check --diff .
+        pylama

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /override.tf
 /terraform.tfvars
 terraform.tfstate*
+.ropeproject/*
+.tox/*

--- a/pylama.ini
+++ b/pylama.ini
@@ -1,0 +1,4 @@
+format = black
+skip = */.tox/*,*/.env/*,.ropeproject/*
+ignore = E501
+max_line_length = 88

--- a/scripts/get_vcenter_ip.py
+++ b/scripts/get_vcenter_ip.py
@@ -15,18 +15,20 @@ def main():
     for line in lines:
         if line:
             options = json.loads(line)
-    subnets = json.loads(options['private_subnets'])
-    public_subnets = json.loads(options['public_subnets'])
-    public_cidrs = json.loads(options['public_cidrs'])
-    vcenter_network = options['vcenter_network']
+    subnets = json.loads(options["private_subnets"])
+    public_subnets = json.loads(options["public_subnets"])
+    public_cidrs = json.loads(options["public_cidrs"])
+    vcenter_network = options["vcenter_network"]
 
     for i in range(0, len(public_subnets)):
-        public_subnets[i]['cidr'] = public_cidrs[i]
+        public_subnets[i]["cidr"] = public_cidrs[i]
         subnets.append(public_subnets[i])
 
     for subnet in subnets:
-        if subnet['name'] == vcenter_network:
-            vcenter_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[1].compressed
+        if subnet["name"] == vcenter_network:
+            vcenter_ip = list(ipaddress.ip_network(subnet["cidr"]).hosts())[
+                1
+            ].compressed
             break
 
     output = {"vcenter_ip": vcenter_ip}

--- a/templates/deploy_vcva.py
+++ b/templates/deploy_vcva.py
@@ -31,12 +31,12 @@ def get_ssl_thumbprint(host_ip):
 
 
 # Vars from Terraform
-private_subnets = "${private_subnets}"
-public_subnets = "${public_subnets}"
+private_subnets = """${private_subnets}"""
+public_subnets = """${public_subnets}"""
 public_cidrs = "${public_cidrs}"
-esx_passwords = "${esx_passwords}"
+esx_passwords = """${esx_passwords}"""
 vcenter_username = "${vcenter_user}@${vcenter_domain}"
-sso_password = "${sso_password}"
+sso_password = """${sso_password}"""
 dc_name = "${dc_name}"
 cluster_name = "${cluster_name}"
 vcenter_network = "${vcenter_network}"

--- a/templates/deploy_vcva.py
+++ b/templates/deploy_vcva.py
@@ -5,7 +5,7 @@ import sys
 import subprocess
 import socket
 from time import sleep
-from pyVmomi import vim, vmodl
+from pyVmomi import vim
 from pyVim import connect
 
 

--- a/templates/deploy_vcva.py
+++ b/templates/deploy_vcva.py
@@ -10,34 +10,44 @@ from pyVim import connect
 
 
 def get_ssl_thumbprint(host_ip):
-    p1 = subprocess.Popen(('echo', '-n'), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    p2 = subprocess.Popen(('openssl', 's_client', '-connect', '{0}:443'.format(host_ip)),
-                          stdin=p1.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    p3 = subprocess.Popen(('openssl', 'x509', '-noout', '-fingerprint', '-sha1'),
-                          stdin=p2.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p1 = subprocess.Popen(
+        ("echo", "-n"), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    p2 = subprocess.Popen(
+        ("openssl", "s_client", "-connect", "{0}:443".format(host_ip)),
+        stdin=p1.stdout,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    p3 = subprocess.Popen(
+        ("openssl", "x509", "-noout", "-fingerprint", "-sha1"),
+        stdin=p2.stdout,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
     out = p3.stdout.read()
-    ssl_thumbprint = out.split(b'=')[-1].strip()
+    ssl_thumbprint = out.split(b"=")[-1].strip()
     return ssl_thumbprint.decode("utf-8")
 
 
 # Vars from Terraform
-private_subnets = '${private_subnets}'
-public_subnets = '${public_subnets}'
-public_cidrs = '${public_cidrs}'
-esx_passwords = '${esx_passwords}'
-vcenter_username ='${vcenter_user}@${vcenter_domain}'
-sso_password = '${sso_password}'
-dc_name = '${dc_name}'
-cluster_name = '${cluster_name}'
-vcenter_network = '${vcenter_network}'
-domain_name = '${domain_name}'
+private_subnets = "${private_subnets}"
+public_subnets = "${public_subnets}"
+public_cidrs = "${public_cidrs}"
+esx_passwords = "${esx_passwords}"
+vcenter_username = "${vcenter_user}@${vcenter_domain}"
+sso_password = "${sso_password}"
+dc_name = "${dc_name}"
+cluster_name = "${cluster_name}"
+vcenter_network = "${vcenter_network}"
+domain_name = "${domain_name}"
 
 # Parse TF Vars
 subnets = json.loads(private_subnets)
 public_subnets = json.loads(public_subnets)
 public_cidrs = json.loads(public_cidrs)
 for i in range(len(public_cidrs)):
-    public_subnets[i]['cidr'] = public_cidrs[i]
+    public_subnets[i]["cidr"] = public_cidrs[i]
     subnets.append(public_subnets[i])
 esx_passes = json.loads(esx_passwords)
 esx = []
@@ -45,35 +55,59 @@ for pw in esx_passes:
     esx.append({"password": pw})
 
 for subnet in subnets:
-    if subnet['vsphere_service_type'] == 'management':
-        esx_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[3].compressed
+    if subnet["vsphere_service_type"] == "management":
+        esx_ip = list(ipaddress.ip_network(subnet["cidr"]).hosts())[3].compressed
         for i in range(len(esx)):
-            esx[i]['private_ip'] = list(ipaddress.ip_network(subnet['cidr']).hosts())[i + 3].compressed
-    if subnet['name'] == vcenter_network:
-        vcenter_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[1].compressed
-        gateway_ip = list(ipaddress.ip_network(subnet['cidr']).hosts())[0].compressed
-        prefix_length = int(subnet['cidr'].split('/')[1])
+            esx[i]["private_ip"] = list(ipaddress.ip_network(subnet["cidr"]).hosts())[
+                i + 3
+            ].compressed
+    if subnet["name"] == vcenter_network:
+        vcenter_ip = list(ipaddress.ip_network(subnet["cidr"]).hosts())[1].compressed
+        gateway_ip = list(ipaddress.ip_network(subnet["cidr"]).hosts())[0].compressed
+        prefix_length = int(subnet["cidr"].split("/")[1])
 
 # If there's only one host, extend the datastore with all available disks
 
 if len(esx) == 1:
-    print(esx[0]['private_ip'])
-    ip = str(esx[0]['private_ip'])
-    command = "chmod a+x $HOME/bootstrap/extend_datastore.sh && $HOME/bootstrap/extend_datastore.sh " + ip + " $HOME/.ssh/esxi_key"
+    print(esx[0]["private_ip"])
+    ip = str(esx[0]["private_ip"])
+    command = (
+        "chmod a+x $HOME/bootstrap/extend_datastore.sh && $HOME/bootstrap/extend_datastore.sh "
+        + ip
+        + " $HOME/.ssh/esxi_key"
+    )
     os.system(command)
 
-os.system("sed -i 's/__ESXI_IP__/{}/g' $HOME/bootstrap/vcva_template.json".format(esx_ip))
-os.system("sed -i 's/__VCENTER_IP__/{}/g' $HOME/bootstrap/vcva_template.json".format(vcenter_ip))
-os.system("sed -i 's/__VCENTER_GATEWAY__/{}/g' $HOME/bootstrap/vcva_template.json".format(gateway_ip))
-os.system("sed -i 's/__VCENTER_PREFIX_LENGTH__/{}/g' $HOME/bootstrap/vcva_template.json".format(prefix_length))
-os.system("/mnt/vcsa-cli-installer/lin64/vcsa-deploy install --accept-eula --acknowledge-ceip "
-          "--no-esx-ssl-verify $HOME/bootstrap/vcva_template.json")
+os.system(
+    "sed -i 's/__ESXI_IP__/{}/g' $HOME/bootstrap/vcva_template.json".format(esx_ip)
+)
+os.system(
+    "sed -i 's/__VCENTER_IP__/{}/g' $HOME/bootstrap/vcva_template.json".format(
+        vcenter_ip
+    )
+)
+os.system(
+    "sed -i 's/__VCENTER_GATEWAY__/{}/g' $HOME/bootstrap/vcva_template.json".format(
+        gateway_ip
+    )
+)
+os.system(
+    "sed -i 's/__VCENTER_PREFIX_LENGTH__/{}/g' $HOME/bootstrap/vcva_template.json".format(
+        prefix_length
+    )
+)
+os.system(
+    "/mnt/vcsa-cli-installer/lin64/vcsa-deploy install --accept-eula --acknowledge-ceip "
+    "--no-esx-ssl-verify $HOME/bootstrap/vcva_template.json"
+)
 
 # Connect to vCenter
 si = None
 for i in range(1, 30):
     try:
-        si = connect.SmartConnectNoSSL(host=vcenter_ip, user=vcenter_username, pwd=sso_password, port=443)
+        si = connect.SmartConnectNoSSL(
+            host=vcenter_ip, user=vcenter_username, pwd=sso_password, port=443
+        )
         break
     except Exception:
         sleep(10)
@@ -89,17 +123,17 @@ dc = folder.CreateDatacenter(name=dc_name)
 cluster_config = vim.cluster.ConfigSpecEx()
 
 # Create DRS config
-drs_config=vim.cluster.DrsConfigInfo()
+drs_config = vim.cluster.DrsConfigInfo()
 drs_config.enabled = True
-cluster_config.drsConfig=drs_config
+cluster_config.drsConfig = drs_config
 
 if len(esx) > 2:
-# Create vSan config
-    vsan_config=vim.vsan.cluster.ConfigInfo()
+    # Create vSan config
+    vsan_config = vim.vsan.cluster.ConfigInfo()
     vsan_config.enabled = True
     vsan_config.defaultConfig = vim.vsan.cluster.ConfigInfo.HostDefaultInfo(
-                                    autoClaimStorage = True
-                                )
+        autoClaimStorage=True
+    )
     cluster_config.vsanConfig = vsan_config
 
 # Create HA config
@@ -116,12 +150,14 @@ cluster = host_folder.CreateClusterEx(name=cluster_name, spec=cluster_config)
 
 # Join hosts to the cluster
 for host in esx:
-    dns_name = "{}.{}".format(socket.gethostbyaddr(host['private_ip'])[0], domain_name)
-    print("Joining host {} with ip {} to the cluster".format(dns_name, host['private_ip']))
+    dns_name = "{}.{}".format(socket.gethostbyaddr(host["private_ip"])[0], domain_name)
+    print(
+        "Joining host {} with ip {} to the cluster".format(dns_name, host["private_ip"])
+    )
     host_connect_spec = vim.host.ConnectSpec()
     host_connect_spec.hostName = dns_name
-    host_connect_spec.userName = 'root'
-    host_connect_spec.password = host['password']
+    host_connect_spec.userName = "root"
+    host_connect_spec.password = host["password"]
     host_connect_spec.force = True
     host_connect_spec.sslThumbprint = get_ssl_thumbprint(dns_name)
     cluster.AddHost(spec=host_connect_spec, asConnected=True)

--- a/templates/esx_host_networking.py
+++ b/templates/esx_host_networking.py
@@ -10,17 +10,17 @@ from subprocess import Popen
 
 
 # Vars from Terraform
-private_subnets = '${private_subnets}'
-private_vlans = '${private_vlans}'
-public_subnets = '${public_subnets}'
-public_vlans = '${public_vlans}'
-public_cidrs = '${public_cidrs}'
-domain_name = '${domain_name}'
-metal_token = '${metal_token}'
+private_subnets = "${private_subnets}"
+private_vlans = "${private_vlans}"
+public_subnets = "${public_subnets}"
+public_vlans = "${public_vlans}"
+public_cidrs = "${public_cidrs}"
+domain_name = "${domain_name}"
+metal_token = "${metal_token}"
 
 # Constants
-vswitch_name = 'vSwitch1'
-del_vswitch_name = 'vSwitch0'
+vswitch_name = "vSwitch1"
+del_vswitch_name = "vSwitch0"
 
 # Build single subnet map with all vlans, cidrs, etc...
 subnets = json.loads(private_subnets)
@@ -30,23 +30,23 @@ public_vlans = json.loads(public_vlans)
 public_cidrs = json.loads(public_cidrs)
 
 for i in range(len(private_vlans)):
-    subnets[i]['vlan'] = private_vlans[i]
+    subnets[i]["vlan"] = private_vlans[i]
 
 for i in range(len(public_vlans)):
-    public_subnets[i]['vlan'] = public_vlans[i]
-    public_subnets[i]['cidr'] = public_cidrs[i]
+    public_subnets[i]["vlan"] = public_vlans[i]
+    public_subnets[i]["cidr"] = public_cidrs[i]
     subnets.append(public_subnets[i])
 
 
 class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
 
 
 def create_vswitch(host_network_system, vss_name, num_ports, nic_name, mtu):
@@ -57,7 +57,7 @@ def create_vswitch(host_network_system, vss_name, num_ports, nic_name, mtu):
 
     host_network_system.AddVirtualSwitch(vswitchName=vss_name, spec=vss_spec)
 
-    print("Successfully created vSwitch ",  vss_name)
+    print("Successfully created vSwitch ", vss_name)
 
 
 def create_port_group(host_network_system, pg_name, vss_name, vlan_id):
@@ -75,14 +75,24 @@ def create_port_group(host_network_system, pg_name, vss_name, vlan_id):
 
     host_network_system.AddPortGroup(portgrp=port_group_spec)
 
-    print("Successfully created PortGroup ",  pg_name)
+    print("Successfully created PortGroup ", pg_name)
 
 
-def add_virtual_nic(host, host_network_system, pg_name, network_type, ip_address, subnet_mask, default_gateway,
-                    dns_servers, domain_name, mtu):
+def add_virtual_nic(
+    host,
+    host_network_system,
+    pg_name,
+    network_type,
+    ip_address,
+    subnet_mask,
+    default_gateway,
+    dns_servers,
+    domain_name,
+    mtu,
+):
     vnic_config = vim.host.VirtualNic.Specification()
     ip_spec = vim.host.IpConfig()
-    if network_type == 'dhcp':
+    if network_type == "dhcp":
         ip_spec.dhcp = True
     else:
         ip_spec.dhcp = False
@@ -113,21 +123,23 @@ def add_virtual_nic(host, host_network_system, pg_name, network_type, ip_address
         host.configManager.networkSystem.UpdateIpRouteConfig(config=routespec)
         host.configManager.networkSystem.UpdateDnsConfig(config=dns_config)
 
-    return(virtual_nic)
+    return virtual_nic
 
 
 def enable_service_on_virtual_nic(host, virtual_nic, service_type):
-    if service_type == 'vsan':
+    if service_type == "vsan":
         vsan_port = vim.vsan.host.ConfigInfo.NetworkInfo.PortConfig(device=virtual_nic)
         net_info = vim.vsan.host.ConfigInfo.NetworkInfo(port=[vsan_port])
-        vsan_config = vim.vsan.host.ConfigInfo(networkInfo=net_info,)
+        vsan_config = vim.vsan.host.ConfigInfo(networkInfo=net_info)
         vsan_system = host.configManager.vsanSystem
         try:
             vsan_task = vsan_system.UpdateVsan_Task(vsan_config)
         except Exception as e:
             print("Failed to set service type to vsan: {}".format(str(e)))
     else:
-        host.configManager.virtualNicManager.SelectVnicForNicType(service_type, virtual_nic)
+        host.configManager.virtualNicManager.SelectVnicForNicType(
+            service_type, virtual_nic
+        )
 
 
 def connect_to_host(esx_host, esx_user, esx_pass):
@@ -135,38 +147,80 @@ def connect_to_host(esx_host, esx_user, esx_pass):
         si = None
         try:
             print("Trying to connect to ESX Host . . .")
-            si = connect.SmartConnectNoSSL(host=esx_host, user=esx_user, pwd=esx_pass, port=443)
+            si = connect.SmartConnectNoSSL(
+                host=esx_host, user=esx_user, pwd=esx_pass, port=443
+            )
             break
         except Exception:
-            print("There was a connection Error to host: {}. Sleeping 10 seconds and trying again.".format(esx_host))
+            print(
+                "There was a connection Error to host: {}. Sleeping 10 seconds and trying again.".format(
+                    esx_host
+                )
+            )
             sleep(10)
         if i == 30:
             return None, None
     print("Connected to ESX Host !")
     content = si.RetrieveContent()
-    host = content.viewManager.CreateContainerView(content.rootFolder, [vim.HostSystem], True).view[0]
+    host = content.viewManager.CreateContainerView(
+        content.rootFolder, [vim.HostSystem], True
+    ).view[0]
     return host, si
 
 
 def main():
-    parser = optparse.OptionParser(usage="%prog --host <host_ip> --user <username> --pass <password> "
-                                   "--id <device_id> --index <terraform_index> --ipRes <ip_reservation>")
-    parser.add_option('--host', dest="host", action="store", help="IP or FQDN of the ESXi host")
-    parser.add_option('--user', dest="user", action="store", help="Username to authenticate to ESXi host")
-    parser.add_option('--pass', dest="pw", action="store", help="Password to authenticarte to ESXi host")
-    parser.add_option('--id', dest="id", action="store", help="Equinix Metal Device ID for Server")
-    parser.add_option('--index', dest="index", action="store", help="Terraform index count, used for IPing")
-    parser.add_option('--ipRes', dest="ipRes", action="store", help="IP reservation for /29 ip block")
+    parser = optparse.OptionParser(
+        usage="%prog --host <host_ip> --user <username> --pass <password> "
+        "--id <device_id> --index <terraform_index> --ipRes <ip_reservation>"
+    )
+    parser.add_option(
+        "--host", dest="host", action="store", help="IP or FQDN of the ESXi host"
+    )
+    parser.add_option(
+        "--user",
+        dest="user",
+        action="store",
+        help="Username to authenticate to ESXi host",
+    )
+    parser.add_option(
+        "--pass",
+        dest="pw",
+        action="store",
+        help="Password to authenticarte to ESXi host",
+    )
+    parser.add_option(
+        "--id", dest="id", action="store", help="Equinix Metal Device ID for Server"
+    )
+    parser.add_option(
+        "--index",
+        dest="index",
+        action="store",
+        help="Terraform index count, used for IPing",
+    )
+    parser.add_option(
+        "--ipRes", dest="ipRes", action="store", help="IP reservation for /29 ip block"
+    )
 
     options, _ = parser.parse_args()
-    if not (options.host and options.user and options.pw and options.id and options.index and options.ipRes):
+    if not (
+        options.host
+        and options.user
+        and options.pw
+        and options.id
+        and options.index
+        and options.ipRes
+    ):
         print("ERROR: Missing arguments")
         parser.print_usage()
         sys.exit(1)
 
     host, si = connect_to_host(options.host, options.user, options.pw)
     if si is None or host is None:
-        print("Couldn't connect to host: {} after 5 minutes. Skipping...".format(options.host))
+        print(
+            "Couldn't connect to host: {} after 5 minutes. Skipping...".format(
+                options.host
+            )
+        )
         sys.exit(1)
 
     host_name = host.name
@@ -180,11 +234,15 @@ def main():
         if len(online_pnics) >= 1:
             break
         else:
-            print("Couldn't find a physical nic with a link speed. Sleeping 10 seconds and checking again.")
+            print(
+                "Couldn't find a physical nic with a link speed. Sleeping 10 seconds and checking again."
+            )
             sleep(10)
 
     if len(online_pnics) <= 0:
-        print(f"{bcolors.FAIL}ERROR: Couldn't find a physical nic with a link speed for over 1 minute. Exiting!!!{bcolors.ENDC}")
+        print(
+            f"{bcolors.FAIL}ERROR: Couldn't find a physical nic with a link speed for over 1 minute. Exiting!!!{bcolors.ENDC}"
+        )
         sys.exit(1)
 
     for vswitch in host_network_system.networkInfo.vswitch:
@@ -195,46 +253,91 @@ def main():
                     break
 
     if len(online_pnics) <= 0:
-        print("No additional uplink is active! Please email support@equinixmetal.com and tell them you think this server has a bad NIC!")
+        print(
+            "No additional uplink is active! Please email support@equinixmetal.com and tell them you think this server has a bad NIC!"
+        )
         sys.exit(1)
 
     uplink = online_pnics[0].device
     create_vswitch(host_network_system, vswitch_name, 1024, uplink, 9000)
     for subnet in subnets:
-        create_port_group(host_network_system, subnet['name'], vswitch_name, subnet['vlan'])
-        if subnet['vsphere_service_type']:
-            ip_address = list(ipaddress.ip_network(subnet['cidr']).hosts())[int(options.index) + 3].compressed
-            subnet_mask = ipaddress.ip_network(subnet['cidr']).netmask.compressed
+        create_port_group(
+            host_network_system, subnet["name"], vswitch_name, subnet["vlan"]
+        )
+        if subnet["vsphere_service_type"]:
+            ip_address = list(ipaddress.ip_network(subnet["cidr"]).hosts())[
+                int(options.index) + 3
+            ].compressed
+            subnet_mask = ipaddress.ip_network(subnet["cidr"]).netmask.compressed
             default_gateway = None
             mtu = 9000
-            if subnet['vsphere_service_type'] == 'management':
-                create_port_group(host_network_system, "Management", vswitch_name, subnet['vlan'])
-                default_gateway = list(ipaddress.ip_network(subnet['cidr']).hosts())[0].compressed
+            if subnet["vsphere_service_type"] == "management":
+                create_port_group(
+                    host_network_system, "Management", vswitch_name, subnet["vlan"]
+                )
+                default_gateway = list(ipaddress.ip_network(subnet["cidr"]).hosts())[
+                    0
+                ].compressed
                 dns_servers = []
                 dns_servers.append(default_gateway)
-                dns_servers.append('8.8.8.8')
+                dns_servers.append("8.8.8.8")
                 mtu = 1500
                 new_ip = ip_address
 
                 # Reserve IP in dnsmasq
-                dnsmasq_conf = open('/etc/dnsmasq.d/dhcp.conf', 'a+')
-                dnsmasq_conf.write("dhcp-host=00:00:00:00:00:{:02x}, {} # {} IP\n".format(int(options.index),
-                                                                                       ip_address,
-                                                                                       host_name))
+                dnsmasq_conf = open("/etc/dnsmasq.d/dhcp.conf", "a+")
+                dnsmasq_conf.write(
+                    "dhcp-host=00:00:00:00:00:{:02x}, {} # {} IP\n".format(
+                        int(options.index), ip_address, host_name
+                    )
+                )
                 dnsmasq_conf.close()
 
                 # DNS record for ESX_Host
-                etc_hosts = open('/etc/hosts', 'a+')
-                etc_hosts.write('{}\t{}\t{}.{}\n'.format(ip_address, host_name, host_name, domain_name))
+                etc_hosts = open("/etc/hosts", "a+")
+                etc_hosts.write(
+                    "{}\t{}\t{}.{}\n".format(
+                        ip_address, host_name, host_name, domain_name
+                    )
+                )
                 etc_hosts.close()
                 # Restart dnsmasq service
-                Popen(["systemctl restart dnsmasq"], shell=True, stdin=None, stdout=None, stderr=None, close_fds=True)
-                virtual_nic = add_virtual_nic(host, host_network_system, "Management", 'static', ip_address,
-                                          subnet_mask, default_gateway, dns_servers, domain_name, mtu)
+                Popen(
+                    ["systemctl restart dnsmasq"],
+                    shell=True,
+                    stdin=None,
+                    stdout=None,
+                    stderr=None,
+                    close_fds=True,
+                )
+                virtual_nic = add_virtual_nic(
+                    host,
+                    host_network_system,
+                    "Management",
+                    "static",
+                    ip_address,
+                    subnet_mask,
+                    default_gateway,
+                    dns_servers,
+                    domain_name,
+                    mtu,
+                )
             else:
-                virtual_nic = add_virtual_nic(host, host_network_system, subnet['name'], 'static', ip_address,
-                                              subnet_mask, "", "", "", mtu)
-            enable_service_on_virtual_nic(host, virtual_nic, subnet['vsphere_service_type'])
+                virtual_nic = add_virtual_nic(
+                    host,
+                    host_network_system,
+                    subnet["name"],
+                    "static",
+                    ip_address,
+                    subnet_mask,
+                    "",
+                    "",
+                    "",
+                    mtu,
+                )
+            enable_service_on_virtual_nic(
+                host, virtual_nic, subnet["vsphere_service_type"]
+            )
     connect.Disconnect(si)
 
     host = None
@@ -248,7 +351,10 @@ def main():
     active_uplinks = []
     backup_uplinks = []
     for vnic in host_network_system.networkInfo.vnic:
-        if vnic.spec.ip.ipAddress == options.host or vnic.spec.ip.ipAddress[:3] == '10.':
+        if (
+            vnic.spec.ip.ipAddress == options.host
+            or vnic.spec.ip.ipAddress[:3] == "10."
+        ):
             print("Removing vNic: {}".format(vnic.device))
             host_network_system.RemoveVirtualNic(vnic.device)
     for vswitch in host_network_system.networkInfo.vswitch:
@@ -272,29 +378,35 @@ def main():
     # This must be done this way because we will be disconnected from the host after this script runs.
     # This script will hang forever and never give an exit code.
     cmd_str = "python3 $HOME/bootstrap/update_uplinks.py --host '{}' --user '{}' --pass '{}' --vswitch '{}' --active-uplinks '{}' --backup-uplinks '{}'".format(
-                                            new_ip, options.user, options.pw, vswitch_name, str_active_uplinks, str_backup_uplinks)
+        new_ip,
+        options.user,
+        options.pw,
+        vswitch_name,
+        str_active_uplinks,
+        str_backup_uplinks,
+    )
     Popen([cmd_str], shell=True, stdin=None, stdout=None, stderr=None, close_fds=True)
 
     # Get Equinix Metal Deivce
     manager = metal.Manager(auth_token=metal_token)
     device = manager.get_device(options.id)
     for port in device.network_ports:
-        if port['type'] == 'NetworkBondPort':
-            print("Found {} port id".format(port['name']))
-            bond_port = port['id']
-        elif port['type'] == 'NetworkPort' and not port['data']['bonded']:
-            print("Found {} port id".format(port['name']))
-            unbonded_port = port['id']
+        if port["type"] == "NetworkBondPort":
+            print("Found {} port id".format(port["name"]))
+            bond_port = port["id"]
+        elif port["type"] == "NetworkPort" and not port["data"]["bonded"]:
+            print("Found {} port id".format(port["name"]))
+            unbonded_port = port["id"]
         else:
-            print("Found {} port id, but...".format(port['name']))
+            print("Found {} port id, but...".format(port["name"]))
             print("This is not the port you're looking for...")
 
     for subnet in subnets:
-        print("Removing vLan {} from unbonded port".format(subnet['vlan']))
+        print("Removing vLan {} from unbonded port".format(subnet["vlan"]))
         attempt = 0
-        for attempt in range(1,10):
+        for attempt in range(1, 10):
             try:
-                manager.remove_port(unbonded_port, subnet['vlan'])
+                manager.remove_port(unbonded_port, subnet["vlan"])
                 break
             except Exception:
                 if attempt == 10:
@@ -304,7 +416,7 @@ def main():
                 sleep(5)
     print("Rebonding Ports...")
     attempt = 0
-    for attempt in range(1,10):
+    for attempt in range(1, 10):
         try:
             manager.bond_ports(bond_port, True)
             break
@@ -316,28 +428,32 @@ def main():
             sleep(5)
     for n in range(len(subnets)):
         if n == 0:
-            print("Adding vLan {} to bond".format(subnets[n]['vlan']))
+            print("Adding vLan {} to bond".format(subnets[n]["vlan"]))
             attempt = 0
-            for attempt in range(1,10):
+            for attempt in range(1, 10):
                 try:
-                    manager.convert_layer_2(bond_port, subnets[n]['vlan'])
+                    manager.convert_layer_2(bond_port, subnets[n]["vlan"])
                     break
                 except Exception:
                     if attempt == 10:
-                        print("Tried to convert bond to Layer 2 ten times and failed. Exiting...")
+                        print(
+                            "Tried to convert bond to Layer 2 ten times and failed. Exiting..."
+                        )
                         sys.exit(1)
                     print("Failed to convert bond to Layer 2, trying again...")
                     sleep(5)
         else:
-            print("Adding vLan {} to bond".format(subnets[n]['vlan']))
+            print("Adding vLan {} to bond".format(subnets[n]["vlan"]))
             attempt = 0
-            for attempt in range(1,10):
+            for attempt in range(1, 10):
                 try:
-                    manager.assign_port(bond_port, subnets[n]['vlan'])
+                    manager.assign_port(bond_port, subnets[n]["vlan"])
                     break
                 except Exception:
                     if attempt == 10:
-                        print("Tried to add vLan to bond ten times and failed. Exiting...")
+                        print(
+                            "Tried to add vLan to bond ten times and failed. Exiting..."
+                        )
                         sys.exit(1)
                     print("Failed to add vLan to bond, trying again...")
                     sleep(5)
@@ -345,7 +461,9 @@ def main():
     try:
         manager.delete_ip(options.ipRes)
     except Exception:
-        print("Failed to cleanup ip reservation... These IPs will cost you some money. You may clean them up manually.")
+        print(
+            "Failed to cleanup ip reservation... These IPs will cost you some money. You may clean them up manually."
+        )
 
 
 # Start program

--- a/templates/esx_host_networking.py
+++ b/templates/esx_host_networking.py
@@ -10,9 +10,9 @@ from subprocess import Popen
 
 
 # Vars from Terraform
-private_subnets = "${private_subnets}"
+private_subnets = """${private_subnets}"""
 private_vlans = "${private_vlans}"
-public_subnets = "${public_subnets}"
+public_subnets = """${public_subnets}"""
 public_vlans = "${public_vlans}"
 public_cidrs = "${public_cidrs}"
 domain_name = "${domain_name}"

--- a/templates/esx_host_networking.py
+++ b/templates/esx_host_networking.py
@@ -4,7 +4,7 @@ import packet as metal
 import optparse
 import sys
 from time import sleep
-from pyVmomi import vim, vmodl
+from pyVmomi import vim
 from pyVim import connect
 from subprocess import Popen
 
@@ -133,7 +133,7 @@ def enable_service_on_virtual_nic(host, virtual_nic, service_type):
         vsan_config = vim.vsan.host.ConfigInfo(networkInfo=net_info)
         vsan_system = host.configManager.vsanSystem
         try:
-            vsan_task = vsan_system.UpdateVsan_Task(vsan_config)
+            vsan_system.UpdateVsan_Task(vsan_config)
         except Exception as e:
             print("Failed to set service type to vsan: {}".format(str(e)))
     else:
@@ -203,7 +203,7 @@ def prepare_parser():
     return parser
 
 
-def main(): # noqa: C901
+def main():  # noqa: C901
     parser = prepare_parser()
     options, _ = parser.parse_args()
     if not (

--- a/templates/esx_host_networking.py
+++ b/templates/esx_host_networking.py
@@ -168,7 +168,7 @@ def connect_to_host(esx_host, esx_user, esx_pass):
     return host, si
 
 
-def main():
+def prepare_parser():
     parser = optparse.OptionParser(
         usage="%prog --host <host_ip> --user <username> --pass <password> "
         "--id <device_id> --index <terraform_index> --ipRes <ip_reservation>"
@@ -200,7 +200,11 @@ def main():
     parser.add_option(
         "--ipRes", dest="ipRes", action="store", help="IP reservation for /29 ip block"
     )
+    return parser
 
+
+def main(): # noqa: C901
+    parser = prepare_parser()
     options, _ = parser.parse_args()
     if not (
         options.host

--- a/templates/pre_reqs.py
+++ b/templates/pre_reqs.py
@@ -6,9 +6,9 @@ import urllib.request as urllib2
 import random
 
 # Vars from Terraform
-private_subnets = "${private_subnets}"
+private_subnets = """${private_subnets}"""
 private_vlans = "${private_vlans}"
-public_subnets = "${public_subnets}"
+public_subnets = """${public_subnets}"""
 public_vlans = "${public_vlans}"
 public_cidrs = "${public_cidrs}"
 domain_name = "${domain_name}"

--- a/templates/update_uplinks.py
+++ b/templates/update_uplinks.py
@@ -10,34 +10,72 @@ def connect_to_host(esx_host, esx_user, esx_pass):
         si = None
         try:
             print("Trying to connect to ESX Host . . .")
-            si = connect.SmartConnectNoSSL(host=esx_host, user=esx_user, pwd=esx_pass, port=443)
+            si = connect.SmartConnectNoSSL(
+                host=esx_host, user=esx_user, pwd=esx_pass, port=443
+            )
             break
         except Exception:
-            print("There was a connection Error to host: {}. Sleeping 10 seconds and trying again.".format(esx_host))
+            print(
+                "There was a connection Error to host: {}. Sleeping 10 seconds and trying again.".format(
+                    esx_host
+                )
+            )
             sleep(10)
         if i == 30:
             return None
     print("Connected to ESX Host !")
     content = si.RetrieveContent()
-    host = content.viewManager.CreateContainerView(content.rootFolder, [vim.HostSystem], True).view[0]
+    host = content.viewManager.CreateContainerView(
+        content.rootFolder, [vim.HostSystem], True
+    ).view[0]
     return host
 
 
 def main():
-    parser = optparse.OptionParser(usage="%prog --host <host_ip> --user <username> --pass <password> "
-                                   "--vswitch <vswitch_name> --active-uplinks <comma_list_uplink_names> "
-                                   "--backup-uplinks <comma_list_uplink_names>")
-    parser.add_option('--host', dest="host", action="store", help="IP or FQDN of the ESXi host")
-    parser.add_option('--user', dest="user", action="store", help="Username to authenticate to ESXi host")
-    parser.add_option('--pass', dest="pw", action="store", help="Password to authenticarte to ESXi host")
-    parser.add_option('--vswitch', dest="vswitch", action="store", help="vSwitch name to be modified")
-    parser.add_option('--active-uplinks', dest="active_uplinks", action="store", help="A comma seperated sting of active "
-                                                                                      "uplinks to be added to the vSwitch")
-    parser.add_option('--backup-uplinks', dest="backup_uplinks", action="store", help="A comma seperated sting of backup "
-                                                                                      "uplinks to be added to the vSwitch")
+    parser = optparse.OptionParser(
+        usage="%prog --host <host_ip> --user <username> --pass <password> "
+        "--vswitch <vswitch_name> --active-uplinks <comma_list_uplink_names> "
+        "--backup-uplinks <comma_list_uplink_names>"
+    )
+    parser.add_option(
+        "--host", dest="host", action="store", help="IP or FQDN of the ESXi host"
+    )
+    parser.add_option(
+        "--user",
+        dest="user",
+        action="store",
+        help="Username to authenticate to ESXi host",
+    )
+    parser.add_option(
+        "--pass",
+        dest="pw",
+        action="store",
+        help="Password to authenticarte to ESXi host",
+    )
+    parser.add_option(
+        "--vswitch", dest="vswitch", action="store", help="vSwitch name to be modified"
+    )
+    parser.add_option(
+        "--active-uplinks",
+        dest="active_uplinks",
+        action="store",
+        help="A comma seperated sting of active " "uplinks to be added to the vSwitch",
+    )
+    parser.add_option(
+        "--backup-uplinks",
+        dest="backup_uplinks",
+        action="store",
+        help="A comma seperated sting of backup " "uplinks to be added to the vSwitch",
+    )
 
     options, _ = parser.parse_args()
-    if not (options.host and options.user and options.pw and options.vswitch and options.active_uplinks):
+    if not (
+        options.host
+        and options.user
+        and options.pw
+        and options.vswitch
+        and options.active_uplinks
+    ):
         print("ERROR: Missing arguments")
         parser.print_usage()
         sys.exit(1)
@@ -51,14 +89,16 @@ def main():
             break
     if vss_spec is None:
         print("Couldn't find the correct vSwitch.")
-    active_uplinks = options.active_uplinks.split(',')
-    backup_uplinks = options.backup_uplinks.split(',')
+    active_uplinks = options.active_uplinks.split(",")
+    backup_uplinks = options.backup_uplinks.split(",")
     all_uplinks = active_uplinks + backup_uplinks
     vss_spec.bridge = vim.host.VirtualSwitch.BondBridge(nicDevice=all_uplinks)
     vss_spec.policy.nicTeaming.nicOrder.activeNic = active_uplinks
     vss_spec.policy.nicTeaming.nicOrder.standbyNic = backup_uplinks
     try:
-        host_network_system.UpdateVirtualSwitch(vswitchName=options.vswitch, spec=vss_spec)
+        host_network_system.UpdateVirtualSwitch(
+            vswitchName=options.vswitch, spec=vss_spec
+        )
     except Exception:
         sys.exit(0)
 

--- a/templates/update_uplinks.py
+++ b/templates/update_uplinks.py
@@ -1,7 +1,7 @@
 import optparse
 import sys
 from time import sleep
-from pyVmomi import vim, vmodl
+from pyVmomi import vim
 from pyVim import connect
 
 

--- a/templates/vsan_claim.py
+++ b/templates/vsan_claim.py
@@ -1,13 +1,6 @@
-import json
-import ipaddress
-import os
-import sys
-import subprocess
-import socket
-from pyVmomi import vim, vmodl
+from pyVmomi import vim
 from pyVim import connect
 import vsanapiutils
-from operator import itemgetter, attrgetter
 import requests
 import ssl
 
@@ -41,7 +34,7 @@ def CollectMultiple(content, objects, parameters, handleNotFound=True):
     pc = content.propertyCollector
     propSet = [vim.PropertySpec(type=objects[0].__class__, pathSet=parameters)]
 
-    while result == None and len(objects) > 0:
+    while result is None and len(objects) > 0:
         try:
             objectSet = []
             for obj in objects:
@@ -130,5 +123,5 @@ for host, disks in diskmap.items():
         )
         task = vsanVcDiskManagementSystem.InitializeDiskMappings(dm)
         tasks.append(task)
-    except expression as identifier:
+    except:  # noqa: E722
         print("Some vSan Claim error... Check vSan...")

--- a/templates/vsan_claim.py
+++ b/templates/vsan_claim.py
@@ -63,7 +63,7 @@ def CollectMultiple(content, objects, parameters, handleNotFound=True):
 # Terraform Vars
 vcenter_fqdn = "${vcenter_fqdn}"
 vcenter_user = "${vcenter_user}@${vcenter_domain}"
-vcenter_pass = "${vcenter_pass}"
+vcenter_pass = """${vcenter_pass}"""
 vcenter_cluster_name = "${vcenter_cluster_name}"
 metal_server_plan = "${plan_type}"
 if metal_server_plan[0].lower() == "s":


### PR DESCRIPTION
Apply `black` formatting in python scripts to avoid style debates and apply a common set of standards.

https://black.readthedocs.io/en/stable/

Terraform object variables have been updated to be encapsulated by `"""` since the preferred quotes from `black` would cause the quoted json blobs to escape otherwise.

https://github.com/equinix/terraform-metal-vsphere/pull/33/files#diff-9d2490267c9225e56a6f5801f9dbec39e80e24f776b533b48a7993295a6864fdR9-R11