### PR TITLE
fix default facility (should be an IBX facility)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,8 +33,8 @@ jobs:
       TF_VAR_vmware_os: ${{ matrix.vsphere.vmware_os }}
       TF_VAR_esxi_host_count: 2
       TF_VAR_esxi_size: "c3.medium.x86"
-      TF_VAR_router_size: "c2.medium.x86"
-      TF_VAR_facility: "sjc1"
+      TF_VAR_router_size: "c3.medium.x86"
+      TF_VAR_facility: "dc13"
       TF_VAR_create_project : false
       # TODO only provide this to terraform steps that need it
       TF_VAR_auth_token: ${{ secrets.METAL_AUTH_TOKEN }}

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,7 +39,7 @@ output "vcenter_password" {
 output "vcenter_root_password" {
   value       = random_string.vcenter_password.result
   sensitive   = true
-  description = "The root password to ssh or login at the console of vCanter."
+  description = "The root password to ssh or login at the console of vCenter."
 }
 
 output "ssh_key_path" {

--- a/templates/deploy_vcva.py
+++ b/templates/deploy_vcva.py
@@ -33,7 +33,7 @@ def get_ssl_thumbprint(host_ip):
 # Vars from Terraform
 private_subnets = """${private_subnets}"""
 public_subnets = """${public_subnets}"""
-public_cidrs = "${public_cidrs}"
+public_cidrs = """${public_cidrs}"""
 esx_passwords = """${esx_passwords}"""
 vcenter_username = "${vcenter_user}@${vcenter_domain}"
 sso_password = """${sso_password}"""

--- a/templates/esx_host_networking.py
+++ b/templates/esx_host_networking.py
@@ -14,7 +14,7 @@ private_subnets = """${private_subnets}"""
 private_vlans = "${private_vlans}"
 public_subnets = """${public_subnets}"""
 public_vlans = "${public_vlans}"
-public_cidrs = "${public_cidrs}"
+public_cidrs = """${public_cidrs}"""
 domain_name = "${domain_name}"
 metal_token = "${metal_token}"
 

--- a/templates/pre_reqs.py
+++ b/templates/pre_reqs.py
@@ -10,7 +10,7 @@ private_subnets = """${private_subnets}"""
 private_vlans = "${private_vlans}"
 public_subnets = """${public_subnets}"""
 public_vlans = "${public_vlans}"
-public_cidrs = "${public_cidrs}"
+public_cidrs = """${public_cidrs}"""
 domain_name = "${domain_name}"
 vcenter_network = "${vcenter_network}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -101,8 +101,8 @@ variable "esxi_size" {
 }
 
 variable "facility" {
-  description = "This is the Region/Location of your deployment."
-  default     = "ny5"
+  description = "This is the Region/Location of your deployment (Must be an IBX facility)"
+  default     = "dc13"
 }
 
 variable "router_os" {


### PR DESCRIPTION
This PR is extracted from #34 which appears to be failing based on password variable changes.

The most recent E2E tests on `main` failed because hybrid-bonding is not available in the facility where the test was run. This PR updates that value. This PR also updates the default facility to one with hybrid-bonding (from ny5 to dc13).

If the tests pass in this PR, then the vsan problem is being introduced in the current branch in #34. 

Fixes #15 
