### PR TITLE
use typed terraform variables and objects

### DIFF
--- a/templates/pre_reqs.py
+++ b/templates/pre_reqs.py
@@ -152,7 +152,7 @@ for subnet in subnets:
 
 interface_file.close()
 
-# Reserver the vCenter IP
+# Reserve the vCenter IP
 dnsmasq_conf.write(
     "\ndhcp-host=00:00:00:00:00:99, {} # vCenter IP\n".format(vcenter_ip)
 )

--- a/variables.tf
+++ b/variables.tf
@@ -1,32 +1,37 @@
 variable "auth_token" {
   description = "This is your Equinix Metal API Auth token"
-  sensitive   = true
   type        = string
+  sensitive   = true
 }
 
 variable "organization_id" {
   description = "Your Equinix Metal Organization Id"
-  default     = "null"
   type        = string
+  default     = "null"
 }
 
 variable "project_name" {
   default     = "vmware-on-metal-1"
+  type        = string
   description = "If 'create_project' is true this will be the project name used."
 }
 
 variable "create_project" {
   description = "if true create the Equinix Metal project, if not skip and use the provided project"
+  type        = bool
   default     = true
 }
 
 variable "project_id" {
   description = "Equinix Metal Project ID to use in case create_project is false"
+  type        = string
   default     = "null"
 }
 
-/*
-Valid vsphere_service_types are:
+variable "private_subnets" {
+  description = <<-EOF
+  This is the network topology for your vSphere Env
+  Valid vsphere_service_types are:
     faultToleranceLogging
     vmotion
     vSphereReplication
@@ -35,12 +40,18 @@ Valid vsphere_service_types are:
     vsan
     management
 
-The subnet name "Management" is reserved for ESXi hosts.
-Whichever subnet is labeled with vsphere_service_type: management will share a vLan with ESXi hosts.
-*/
+  The subnet name "Management" is reserved for ESXi hosts.
+  Whichever subnet is labeled with vsphere_service_type: management will share a vLan with ESXi hosts.
+  EOF
 
-variable "private_subnets" {
-  description = "This is the network topology for your vSphere Env"
+  type = list(object({
+    name                 = string,
+    nat                  = bool,
+    vsphere_service_type = string,
+    routable             = bool,
+    cidr                 = string,
+    reserved_ip_count    = optional(number)
+  }))
   default = [
     {
       "name" : "VM Private Net 1",
@@ -69,6 +80,13 @@ variable "private_subnets" {
 
 variable "public_subnets" {
   description = "This will dynamically create public subnets in vSphere"
+  type = list(object({
+    name                 = string,
+    nat                  = bool,
+    vsphere_service_type = optional(string),
+    routable             = bool,
+    ip_count             = number
+  }))
   default = [
     {
       "name" : "VM Public Net 1",
@@ -82,133 +100,159 @@ variable "public_subnets" {
 
 variable "router_hostname" {
   description = "This is the hostname for the router."
+  type        = string
   default     = "edge-gateway01"
 }
 
 variable "esxi_hostname" {
   description = "This is the hostname prefix for your esxi hosts. A number will be added to the end."
+  type        = string
   default     = "esx"
 }
 
 variable "router_size" {
   description = "This is the size/plan/flavor of your router machine"
+  type        = string
   default     = "c3.small.x86"
 }
 
 variable "esxi_size" {
   description = "This is the size/plan/flavor of your ESXi machine(s)"
+  type        = string
   default     = "c3.medium.x86"
 }
 
 variable "facility" {
   description = "This is the Region/Location of your deployment (Must be an IBX facility, Metro will be used if empty)"
+  type        = string
   default     = ""
 }
 
 variable "metro" {
   description = "This is the Metro Location of your deployment. (Facility will be used if empty)"
+  type        = string
   default     = ""
 }
 
 variable "router_os" {
   description = "This is the operating System for you router machine (Only Ubuntu 18.04 has been tested)"
+  type        = string
   default     = "ubuntu_18_04"
 }
 
 variable "vmware_os" {
   description = "This is the version of vSphere that you want to deploy (ESXi 6.5, 6.7, & 7.0 have been tested)"
+  type        = string
   default     = "vmware_esxi_7_0"
 }
 
 variable "billing_cycle" {
   description = "This is billing cycle to use. The hasn't beend built to allow reserved isntances yet."
+  type        = string
   default     = "hourly"
 }
 
 variable "esxi_host_count" {
   description = "This is the number of ESXi host you'd like in your cluster."
+  type        = number
   default     = 3
 }
 
 variable "vcenter_portgroup_name" {
   description = "This is the VM Portgroup you would like vCenter to be deployed to. See 'private_subnets' & 'public_subnets' above. By deploying on a public subnet, you will not need to use the VPN to access vCenter."
+  type        = string
   default     = "VM Public Net 1"
 }
 
 variable "domain_name" {
   description = "This is the domain to use for internal DNS"
+  type        = string
   default     = "metal.local"
 }
 
 variable "vpn_user" {
   description = "This is the username for the L2TP VPN"
+  type        = string
   default     = "vm_admin"
 }
 
 variable "vcenter_datacenter_name" {
   description = "This will be the name of the vCenter Datacenter object."
+  type        = string
   default     = "Metal"
 }
 
 variable "vcenter_cluster_name" {
   description = "This will be the name of the vCenter Cluster object."
+  type        = string
   default     = "Metal-1"
 }
 
 variable "vcenter_domain" {
   description = "This will be the vSphere SSO domain."
+  type        = string
   default     = "vsphere.local"
 }
 
 variable "vcenter_user_name" {
   description = "This will be the admin user for vSphere SSO"
+  type        = string
   default     = "Administrator"
 }
 
 variable "s3_url" {
   description = "This is the URL endpoint to connect your s3 client to"
+  type        = string
   default     = "https://s3.example.com"
 }
 
 variable "s3_access_key" {
   description = "This is the access key for your S3 endpoint"
+  type        = string
   sensitive   = true
   default     = "S3_ACCESS_KEY"
 }
 
 variable "s3_secret_key" {
   description = "This is the secret key for your S3 endpoint"
+  type        = string
   sensitive   = true
   default     = "S3_SECRET_KEY"
 }
 
 variable "s3_version" {
   description = "S3 API Version (S3v2, S3v4)"
+  type        = string
   default     = "S3v4"
 }
 
 variable "object_store_tool" {
   description = "Which tool should you use to download objects from the object store? ('mc' and 'gcs' have been tested.)"
+  type        = string
   default     = "mc"
 }
 
 variable "object_store_bucket_name" {
   description = "This is the name of the bucket on your Object Store"
+  type        = string
   default     = "vmware"
 }
 
 variable "gcs_key_name" {
   description = "If you are using GCS to download your vCenter ISO this is the name of the GCS key"
+  type        = string
   default     = "storage-reader-key.json"
 }
 
 variable "path_to_gcs_key" {
   description = "If you are using GCS to download your vCenter ISO this is the absolute path to the GCS key (ex: /home/example/storage-reader-key.json)"
+  type        = string
   default     = ""
 }
 
 variable "relative_path_to_gcs_key" {
   description = "(Deprecated: use path_to_gcs_key) If you are using GCS to download your vCenter ISO this is the path to the GCS key"
+  type        = string
   default     = ""
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  experiments = [module_variable_optional_attrs]
   required_providers {
     null = {
       source = "hashicorp/null"


### PR DESCRIPTION
When variables are defined in the wrong type, the conditional checks in the Terraform configs can fail.

One example of this is https://github.com/equinix/terraform-metal-vsphere/issues/20#issuecomment-809657817 where my esxi_host_count was set to `"1"`.

Use typed variables to prevent misinterpretation and trigger early validation errors for the more complex types.