### PR TITLE
resolve HOME in ssh_key_path output variable

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -43,7 +43,7 @@ output "vcenter_root_password" {
 }
 
 output "ssh_key_path" {
-  value       = "$HOME/.ssh/${local.ssh_key_name}"
+  value       = pathexpand("~/.ssh/${local.ssh_key_name}")
   description = "The path of to the private SSH key created for this deployment"
 }
 


### PR DESCRIPTION

Avoid `$HOME` being sent unprocessed in the SSH key output variable, as in https://github.com/equinix/terraform-metal-anthos-on-vsphere/pull/127

The `file()` function will not process `$HOME` and it will error that the path is outside of the module directory.  Hashicorp recommends using the https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file data source instead of the `file()` function for this purpose.

In order to have this data source process path, we can use `pathexpand()` which will *only* replace `~` with `$HOME` (it will not handle `$HOME` in the string). https://www.terraform.io/docs/language/functions/pathexpand.html

... On second thought, rather than return `~/...`, this module should return the absolute path (run pathexpand in this module).





This change will help us prevent:
```
Error: Invalid function argument
│ 
│   on 33-anthos-deploy-admin-workstation.tf line 67, in resource "null_resource" "anthos_deploy_workstation":
│   67:     private_key = file(module.vsphere.ssh_key_path)
│     ├────────────────
│     │ module.vsphere.ssh_key_path is "$HOME/.ssh/marques-anthos-project-9wtgd-key"
│ 
│ Invalid value for "path" parameter: no file exists at $HOME/.ssh/marques-anthos-project-9wtgd-key; this function works only with files that are distributed as part of the
│ configuration source code, so if this file will be created by a resource in this configuration you must instead obtain this result from an attribute of that resource.
```