### PR TITLE
Block open inernet

### DIFF
--- a/templates/l2tp_vpn.sh
+++ b/templates/l2tp_vpn.sh
@@ -408,10 +408,13 @@ if [ "$ipt_flag" = "1" ]; then
   iptables -I FORWARD 8 -s "$SA2_IP" -j ACCEPT
   iptables -I FORWARD 9 -s "$SA3_IP" -j ACCEPT
   iptables -I FORWARD 10 -s 172.16.0.0/24 -j ACCEPT
+  iptables -I FORWARD 11 -s "$PUBNET" -j ACCEPT
+  iptables -I FORWARD 12 -i "$NET_IFACE" -d "$PUBNET" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+  iptables -I FORWARD 13 -i "$NET_IFACE" -d "$PUBNET" -j DROP
   # Uncomment if you wish to disallow traffic between VPN clients themselves
   # iptables -I FORWARD 2 -i ppp+ -o ppp+ -s "$L2TP_NET" -d "$L2TP_NET" -j DROP
   # iptables -I FORWARD 3 -s "$XAUTH_NET" -d "$XAUTH_NET" -j DROP
-  iptables -A FORWARD -j DROP
+  # iptables -A FORWARD -j DROP
   iptables -t nat -I POSTROUTING -s "$XAUTH_NET" -o "$NET_IFACE" -m policy --dir out --pol none -j MASQUERADE
   iptables -t nat -I POSTROUTING -s "$L2TP_NET" -o "$NET_IFACE" -j MASQUERADE
   iptables -t nat -I POSTROUTING -s 172.16.0.0/24 -o "$NET_IFACE" -j MASQUERADE


### PR DESCRIPTION
This change blocks open internet connections from reaching the routed public address space that the Vcenter web interface uses.
This stops anyone accessing the web interface over the internet.
To access Vcenter you would either need to add your IP address to one of the vars:
SA1_IP
SA2_IP
SA3_IP
or use the L2TP VPN for access
