### PR TITLE
download a known working version of minio client

### DIFF
--- a/templates/download_vcenter.sh
+++ b/templates/download_vcenter.sh
@@ -29,8 +29,8 @@ if [ $object_store_tool = "gcs" ]; then
   gsutil cp gs://${object_store_bucket_name}/vsanmgmtObjects.py .
 elif [ $object_store_tool = "mc" ]; then
   echo "USING S3"
-  curl -LO https://dl.min.io/client/mc/release/linux-amd64/mc
-  chmod +x mc
+  curl -Lo mc https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2022-01-07T06-01-38Z
+  echo -n '33d25b2242626d1e07ce7341a9ecc2164c0ef5c0  mc' | shasum -a1 -c - && chmod +x mc
   mv mc /usr/local/bin/
   mc config host add s3 ${s3_url} ${s3_access_key} ${s3_secret_key}
   mc cp s3/${object_store_bucket_name}/${vcenter_iso_name} .


### PR DESCRIPTION
fixes #50

This change will ensure that a known working (unmodified) version of `mc` is fetched.

The following new text will appear in the provisioning output:
```
mc: OK
```


In this PR, if `mc` fails to download or does not match the known checksum, a more visible warning is displayed:

```
mc: FAILED
shasum: WARNING: 1 computed checksum did NOT match
```

If this can not be fetched the proceeding lines will fail, as they always have.  Additional errors will bubble up from there (can't `chmod`, can't `mv`, can't execute `mc`).

Ideally, this `bash` script would be run with `-e` to fail immediately on error. I haven't been able to verify if this is a safe assumption to make for the rest of the script.
