### PR TITLE
fix $HOME expansion bug

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -194,12 +194,12 @@ resource "null_resource" "run_pre_reqs" {
       metal_token          = var.auth_token,
     })
 
-    destination = "$HOME/bootstrap/vars.py"
+    destination = "bootstrap/vars.py"
   }
 
   provisioner "file" {
     content     = file("${path.module}/templates/pre_reqs.py")
-    destination = "$HOME/bootstrap/pre_reqs.py"
+    destination = "bootstrap/pre_reqs.py"
   }
 
   provisioner "remote-exec" {
@@ -232,7 +232,7 @@ resource "null_resource" "copy_gcs_key" {
   }
   provisioner "file" {
     content     = file(local.gcs_key_path)
-    destination = "$HOME/bootstrap/gcp_storage_reader.json"
+    destination = "bootstrap/gcp_storage_reader.json"
   }
 }
 
@@ -250,12 +250,7 @@ resource "null_resource" "download_vcenter_iso" {
 
   provisioner "file" {
     content     = data.template_file.download_vcenter.rendered
-    destination = "$HOME/bootstrap/download_vcenter.sh"
-  }
-
-  provisioner "file" {
-    content     = data.template_file.download_vcenter.rendered
-    destination = "$HOME/bootstrap/download_vcenter.sh"
+    destination = "bootstrap/download_vcenter.sh"
   }
 
   provisioner "remote-exec" {
@@ -283,6 +278,7 @@ resource "random_password" "vpn_pass" {
   special          = true
 }
 
+
 data "template_file" "vpn_installer" {
   template = file("${path.module}/templates/l2tp_vpn.sh")
   vars = {
@@ -306,7 +302,7 @@ resource "null_resource" "install_vpn_server" {
 
   provisioner "file" {
     content     = data.template_file.vpn_installer.rendered
-    destination = "$HOME/bootstrap/vpn_installer.sh"
+    destination = "bootstrap/vpn_installer.sh"
   }
 
   provisioner "remote-exec" {
@@ -356,7 +352,7 @@ resource "null_resource" "copy_vcva_template" {
       vcenter_domain   = var.vcenter_domain,
     })
 
-    destination = "$HOME/bootstrap/vcva_template.json"
+    destination = "bootstrap/vcva_template.json"
   }
 }
 
@@ -371,7 +367,7 @@ resource "null_resource" "copy_update_uplinks" {
 
   provisioner "file" {
     content     = file("${path.module}/templates/update_uplinks.py")
-    destination = "$HOME/bootstrap/update_uplinks.py"
+    destination = "bootstrap/update_uplinks.py"
   }
 }
 
@@ -386,7 +382,7 @@ resource "null_resource" "esx_network_prereqs" {
 
   provisioner "file" {
     content     = file("${path.module}/templates/esx_host_networking.py")
-    destination = "$HOME/bootstrap/esx_host_networking.py"
+    destination = "bootstrap/esx_host_networking.py"
   }
 }
 
@@ -425,17 +421,17 @@ resource "null_resource" "deploy_vcva" {
 
   provisioner "file" {
     source      = "${path.module}/templates/extend_datastore.sh"
-    destination = "$HOME/bootstrap/extend_datastore.sh"
+    destination = "bootstrap/extend_datastore.sh"
   }
 
   provisioner "file" {
     content     = file("${path.module}/templates/vsan_claim.py")
-    destination = "$HOME/bootstrap/vsan_claim.py"
+    destination = "bootstrap/vsan_claim.py"
   }
 
   provisioner "file" {
     content     = file("${path.module}/templates/deploy_vcva.py")
-    destination = "$HOME/bootstrap/deploy_vcva.py"
+    destination = "bootstrap/deploy_vcva.py"
   }
 
   provisioner "remote-exec" {


### PR DESCRIPTION
fix for #52
- expansion of $HOME env variable in file provisioners won't work with
  newer versions of Terraform due to hashicorp/terraform/issues/30243
- removed a redundant file provisioner