### PR TITLE
allow customizing virtual appliance size

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -344,12 +344,13 @@ resource "null_resource" "copy_vcva_template" {
 
   provisioner "file" {
     content = templatefile("${path.module}/templates/vcva_template.json", {
-      vcenter_password = random_password.vcenter_password.result,
-      sso_password     = random_password.sso_password.result,
-      first_esx_pass   = metal_device.esxi_hosts.0.root_password,
-      domain_name      = var.domain_name,
-      vcenter_network  = var.vcenter_portgroup_name,
-      vcenter_domain   = var.vcenter_domain,
+      vcenter_password        = random_password.vcenter_password.result,
+      sso_password            = random_password.sso_password.result,
+      first_esx_pass          = metal_device.esxi_hosts.0.root_password,
+      domain_name             = var.domain_name,
+      vcenter_network         = var.vcenter_portgroup_name,
+      vcenter_domain          = var.vcenter_domain,
+      vcva_deployment_option  = var.vcva_deployment_option
     })
 
     destination = "bootstrap/vcva_template.json"

--- a/templates/vcva_template.json
+++ b/templates/vcva_template.json
@@ -10,7 +10,7 @@
     },
     "appliance": {
       "thin_disk_mode": true,
-      "deployment_option": "small",
+      "deployment_option": "${vcva_deployment_option}",
       "name": "vcva"
     },
     "network": {

--- a/variables.tf
+++ b/variables.tf
@@ -274,3 +274,14 @@ variable "reservations" {
   type        = map(any)
   default     = {}
 }
+
+variable "vcva_deployment_option" {
+  description = <<-EOF
+  Size of the vCenter appliance: tiny, tiny-lstorage, ..., small, etc.
+  Each option has different CPU, memory, and storage requirements.
+  For the full list of options, see
+  https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vcenter.install.doc/GUID-457EAE1F-B08A-4E64-8506-8A3FA84A0446.html#GUID-457EAE1F-B08A-4E64-8506-8A3FA84A0446__row_5D65E7455996456CBDCB3EF9A7DCDC62__entry__1
+  EOF
+  type        = string
+  default     = "small"
+}


### PR DESCRIPTION
Add a variable for vCenter virtual appliance depoyment_option (tiny,
small, etc.). The default behavior remains unchanged - small.